### PR TITLE
Support for german

### DIFF
--- a/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
+++ b/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
@@ -114,4 +114,32 @@ class DateTimeAgoSpec extends ObjectBehavior
 
     }
 
+    function it_checks_german()
+    {
+        $this->setTextTranslator(new \Smirik\PHPDateTimeAgo\TextTranslator\GermanTextTranslator());
+
+        //now
+        $this->get(new \DateTime())->shouldReturn('jetzt');
+        $this->get(new \DateTime('-5 seconds'))->shouldReturn('jetzt');
+        $this->get(new \DateTime('-25 seconds'))->shouldReturn('jetzt');
+        $this->get(new \DateTime('-59 seconds'))->shouldReturn('jetzt');
+
+        //minutes
+        $this->get(new \DateTime('-1 minutes'))->shouldBe('vor einer Minute');
+        $this->get(new \DateTime('-3 minutes'))->shouldBe('vor 3 Minuten');
+        $this->get(new \DateTime('-25 minutes'))->shouldBe('vor 25 Minuten');
+        $this->get(new \DateTime('-59 minutes'))->shouldBe('vor 59 Minuten');
+        $this->get(new \DateTime('-61 minutes'))->shouldBe('vor einer Stunde');
+
+        //hours
+        $this->get(new \DateTime('-90 minutes'))->shouldBe('vor einer Stunde');
+        $this->get(new \DateTime('-119 minutes'))->shouldBe('vor einer Stunde');
+        $this->get(new \DateTime('-2 hours'))->shouldBe('vor 2 Stunden');
+
+        //days
+        $this->get(new \DateTime('-24 hours'))->shouldBe('vor einem Tag');
+        $this->get(new \DateTime('-2 days'))->shouldBe('vor 2 Tagen');
+        $this->get(new \DateTime('-5 days'))->shouldBe('vor 5 Tagen');
+    }
+
 }

--- a/src/Smirik/PHPDateTimeAgo/TextTranslator/GermanTextTranslator.php
+++ b/src/Smirik/PHPDateTimeAgo/TextTranslator/GermanTextTranslator.php
@@ -1,0 +1,66 @@
+<?php
+
+namespace Smirik\PHPDateTimeAgo\TextTranslator;
+
+class GermanTextTranslator implements TextTranslatorInterface
+{
+    protected $pre_word = 'vor';
+    protected $one_words = array('einer', 'einem'); //0 for minutes and hours, 1 for days
+    protected $minute_words = array('Minute', 'Minuten');
+    protected $hour_words = array('Stunde', 'Stunden');
+    protected $day_words = array('Tag', 'Tagen');
+
+    /**
+     * Gets used by minutes(), hours() and days(), does the actual formatting work.
+     */
+    protected function format($number, $oneWord, $typeWords)
+    {
+        $typeWord = $typeWords[$this->pluralization($number)];
+        if ($number === 1) {
+            $number = $oneWord;
+        }
+        return $this->pre_word . ' ' . $number . ' ' . $typeWord;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function now()
+    {
+        return 'jetzt';
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function minutes($minutes)
+    {
+        return $this->format($minutes, $this->one_words[0], $this->minute_words);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function hours($hours)
+    {
+        return $this->format($hours, $this->one_words[0], $this->hour_words);
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function days($days)
+    {
+        return $this->format($days, $this->one_words[1], $this->day_words);
+    }
+
+    /**
+     * Pluralize the number. Returns key in related array (minute_words, hour_words, day_words)
+     * @param integer $number
+     * @return integer
+     */
+    public function pluralization($number)
+    {
+        return $number === 1 ? 0 : 1;
+    }
+}


### PR DESCRIPTION
Hey,
this pull-request adds support for german (`GermanTextTranslator`).

I wanted to use `AbstractTextTranslator` at first (like the others do), but german is quite a complicate language (compared to others) and after finding myself on overwriting all the methods the abstract class has, i decided to just implement the `TextTranslatorInterface` and throw the abstract class away. I tried to copy the coding-style of the abstract class tho.

I also extended the specs for the new language.

At last, i need to thank you for this package. Seems like this is the only one, which supports multiple languages and is not bound to a big framework. I also like the implementation of the translators as classes, otherwise it would maybe not be possible to implement such languages like german. :) 
