### PR TITLE
Fix implementation of weeks, months and years and round consistently

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Examples
 | Between 1 and 2 hours | 1 hour ago |
 | Between 2 and 24 hours | xx hours ago |
 | Between 1 and 2 days | 1 day ago |
-| Between 2 and 10 days | xx days ago |
-| More than 10 days ago | xx weeks ago |
-| More than 30 days ago | xx months ago |
-| More than 365 days ago | xx years ago |
+| Between 2 and 6 days | xx days ago |
+| 7 or more days ago | xx weeks ago |
+| 30 or more days ago | xx months ago |
+| 365 or more days ago | xx years ago |
 
 Notice that not every translator supports weeks, months and years
 
@@ -47,7 +47,7 @@ Russian translation:
 Customization
 -------------
 
-#### Date formatter for more than 10 days
+#### Date formatter for more than 6 days
 
 ```php
 <?php

--- a/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
+++ b/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
@@ -163,4 +163,41 @@ class DateTimeAgoSpec extends ObjectBehavior
 
     }
 
+    function it_checks_polish()
+    {
+        $this->setTextTranslator(new \Smirik\PHPDateTimeAgo\TextTranslator\PolishTextTranslator);
+
+        $this->get(new \DateTime())->shouldBe('teraz');
+        $this->get(new \DateTime('-5 seconds'))->shouldReturn('teraz');
+        $this->get(new \DateTime('-25 seconds'))->shouldReturn('teraz');
+        $this->get(new \DateTime('-59 seconds'))->shouldReturn('teraz');
+
+        $this->get(new \DateTime('-1 minutes'))->shouldBe('1 minutę temu');
+        $this->get(new \DateTime('-3 minutes'))->shouldBe('3 minuty temu');
+        $this->get(new \DateTime('-25 minutes'))->shouldBe('25 minut temu');
+        $this->get(new \DateTime('-59 minutes'))->shouldBe('59 minut temu');
+        $this->get(new \DateTime('-61 minutes'))->shouldBe('1 godzinę temu');
+
+        $this->get(new \DateTime('-121 minutes'))->shouldBe('2 godziny temu');
+
+        $this->get(new \DateTime('-24 hours'))->shouldBe('1 dzień temu');
+        $this->get(new \DateTime('-2 days'))->shouldBe('2 dni temu');
+        $this->get(new \DateTime('-5 days'))->shouldBe('5 dni temu');
+        $this->get(new \DateTime('-6 days'))->shouldBe('6 dni temu');
+
+        $this->get(new \DateTime('-7 days'))->shouldBe('1 tydzień temu');
+        $this->get(new \DateTime('-18 days'))->shouldBe('2 tygodnie temu');
+        $this->get(new \DateTime('-29 days'))->shouldBe('4 tygodnie temu');
+
+        $this->get(new \DateTime('-30 days'))->shouldBe('1 miesiąc temu');
+        $this->get(new \DateTime('2015-09-08'), new \DateTime('2015-08-06'))->shouldBe('1 miesiąc temu');
+        $this->get(new \DateTime('-80 days'))->shouldBe('2 miesiące temu');
+        $this->get(new \DateTime('-364 days'))->shouldBe('11 miesięcy temu');
+
+        $this->get(new \DateTime('-365 days'))->shouldBe('1 rok temu');
+        $this->get(new \DateTime('-729 days'))->shouldBe('1 rok temu');
+        $this->get(new \DateTime('-730 days'))->shouldBe('2 lata temu');
+        $this->get(new \DateTime('-95 years'))->shouldBe('95 lat temu');
+    }
+
 }

--- a/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
+++ b/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
@@ -159,8 +159,8 @@ class DateTimeAgo
      */
     public function days(DateInterval $diff)
     {
-        if ($diff->d <= $this->max_days_count) {
-            return $diff->d;
+        if ($diff->days <= $this->max_days_count) {
+            return $diff->days;
         }
         return false;
     }
@@ -172,9 +172,8 @@ class DateTimeAgo
      */
     public function weeks(DateInterval $diff)
     {
-        $x = (int) round($diff->d / 7, 0);
-        if ($x < 4) {
-            return $x;
+        if ($diff->days < 30) {
+            return (int) floor($diff->days / 7);
         }
         return false;
     }
@@ -186,11 +185,16 @@ class DateTimeAgo
      */
     public function months(DateInterval $diff)
     {
-        $x = (int) round($diff->d / 30, 0);
-        if ($x < 12) {
+        if ($diff->days >= 365) {
+            return FALSE;
+        }
+
+        $x = (int) floor($diff->days / 30.417);
+        if ($x === 0) {
+            return 1;
+        } else {
             return $x;
         }
-        return false;
     }
 
     /**
@@ -200,7 +204,7 @@ class DateTimeAgo
      */
     public function years(DateInterval $diff)
     {
-        return (int) round($diff->d / 365, 0);
+        return (int) floor($diff->days / 365);
     }
     
     /**


### PR DESCRIPTION
The implementation for longer periods introduced in smirik/php-datetime-ago#7
introduced a number of edge cases (including rendering periods of eg
1 month and 2 days as `2 days ago` due to the use of $diff->d rather than
$diff->days).

Additionally the calculation of periods did not match the documentation
and weeks, months and years were rounded up or down - this is inconsistent
with behaviour for smaller time periods.

Added additional tests for the polish translations to verify expected
results over a wider range of times and fixed the DateTimeAgo class
to pass all these specifications.
