### PR TITLE
Add optional support for weeks, months and years in English translator

### DIFF
--- a/README.md
+++ b/README.md
@@ -13,10 +13,10 @@ Examples
 | Between 1 and 2 hours | 1 hour ago |
 | Between 2 and 24 hours | xx hours ago |
 | Between 1 and 2 days | 1 day ago |
-| Between 2 and 10 days | xx days ago |
-| More than 10 days ago | xx weeks ago |
-| More than 30 days ago | xx months ago |
-| More than 365 days ago | xx years ago |
+| Between 2 and 6 days | xx days ago |
+| 7 or more days ago | xx weeks ago |
+| 30 or more days ago | xx months ago |
+| 365 or more days ago | xx years ago |
 
 Notice that not every translator supports weeks, months and years
 
@@ -47,7 +47,7 @@ Russian translation:
 Customization
 -------------
 
-#### Date formatter for more than 10 days
+#### Date formatter for more than 6 days
 
 ```php
 <?php

--- a/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
+++ b/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
@@ -163,4 +163,41 @@ class DateTimeAgoSpec extends ObjectBehavior
 
     }
 
+    function it_checks_polish()
+    {
+        $this->setTextTranslator(new \Smirik\PHPDateTimeAgo\TextTranslator\PolishTextTranslator);
+
+        $this->get(new \DateTime())->shouldBe('teraz');
+        $this->get(new \DateTime('-5 seconds'))->shouldReturn('teraz');
+        $this->get(new \DateTime('-25 seconds'))->shouldReturn('teraz');
+        $this->get(new \DateTime('-59 seconds'))->shouldReturn('teraz');
+
+        $this->get(new \DateTime('-1 minutes'))->shouldBe('1 minutę temu');
+        $this->get(new \DateTime('-3 minutes'))->shouldBe('3 minuty temu');
+        $this->get(new \DateTime('-25 minutes'))->shouldBe('25 minut temu');
+        $this->get(new \DateTime('-59 minutes'))->shouldBe('59 minut temu');
+        $this->get(new \DateTime('-61 minutes'))->shouldBe('1 godzinę temu');
+
+        $this->get(new \DateTime('-121 minutes'))->shouldBe('2 godziny temu');
+
+        $this->get(new \DateTime('-24 hours'))->shouldBe('1 dzień temu');
+        $this->get(new \DateTime('-2 days'))->shouldBe('2 dni temu');
+        $this->get(new \DateTime('-5 days'))->shouldBe('5 dni temu');
+        $this->get(new \DateTime('-6 days'))->shouldBe('6 dni temu');
+
+        $this->get(new \DateTime('-7 days'))->shouldBe('1 tydzień temu');
+        $this->get(new \DateTime('-18 days'))->shouldBe('2 tygodnie temu');
+        $this->get(new \DateTime('-29 days'))->shouldBe('4 tygodnie temu');
+
+        $this->get(new \DateTime('-30 days'))->shouldBe('1 miesiąc temu');
+        $this->get(new \DateTime('2015-09-08'), new \DateTime('2015-08-06'))->shouldBe('1 miesiąc temu');
+        $this->get(new \DateTime('-80 days'))->shouldBe('2 miesiące temu');
+        $this->get(new \DateTime('-364 days'))->shouldBe('11 miesięcy temu');
+
+        $this->get(new \DateTime('-365 days'))->shouldBe('1 rok temu');
+        $this->get(new \DateTime('-729 days'))->shouldBe('1 rok temu');
+        $this->get(new \DateTime('-730 days'))->shouldBe('2 lata temu');
+        $this->get(new \DateTime('-95 years'))->shouldBe('95 lat temu');
+    }
+
 }

--- a/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
+++ b/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
@@ -71,6 +71,37 @@ class DateTimeAgoSpec extends ObjectBehavior
         $this->get(new \DateTime('-5 days'))->shouldNotBe('5 days ago');
     }
 
+    function it_checks_weeks_in_english_when_enabled()
+    {
+        $translator = new \Smirik\PHPDateTimeAgo\TextTranslator\EnglishTextTranslator;
+        $translator->enableWeeksMonthsYears(TRUE);
+        $this->setTextTranslator($translator);
+        $this->get(new \DateTime('-6 days'))->shouldBe('6 days ago');
+        $this->get(new \DateTime('-7 days'))->shouldBe('1 week ago');
+        $this->get(new \DateTime('-14 days'))->shouldBe('2 weeks ago');
+        $this->get(new \DateTime('-29 days'))->shouldBe('4 weeks ago');
+    }
+
+    function it_checks_months_in_english_when_enabled()
+    {
+        $translator = new \Smirik\PHPDateTimeAgo\TextTranslator\EnglishTextTranslator;
+        $translator->enableWeeksMonthsYears(TRUE);
+        $this->setTextTranslator($translator);
+        $this->get(new \DateTime('-30 days'))->shouldBe('1 month ago');
+        $this->get(new \DateTime('-70 days'))->shouldBe('2 months ago');
+        $this->get(new \DateTime('-364 days'))->shouldBe('11 months ago');
+    }
+
+    function it_checks_years_in_english_when_enabled()
+    {
+        $translator = new \Smirik\PHPDateTimeAgo\TextTranslator\EnglishTextTranslator;
+        $translator->enableWeeksMonthsYears(TRUE);
+        $this->setTextTranslator($translator);
+        $this->get(new \DateTime('-365 days'))->shouldBe('1 year ago');
+        $this->get(new \DateTime('-729 days'))->shouldBe('1 year ago');
+        $this->get(new \DateTime('-15 years'))->shouldBe('15 years ago');
+    }
+
     function it_checks_format()
     {
         $this->get(new \DateTime('2001-01-01 23:59'), new \DateTime('2001-01-20 01:00'))->shouldBe('2001-01-01');

--- a/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
+++ b/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
@@ -159,8 +159,8 @@ class DateTimeAgo
      */
     public function days(DateInterval $diff)
     {
-        if ($diff->d <= $this->max_days_count) {
-            return $diff->d;
+        if ($diff->days <= $this->max_days_count) {
+            return $diff->days;
         }
         return false;
     }
@@ -172,9 +172,8 @@ class DateTimeAgo
      */
     public function weeks(DateInterval $diff)
     {
-        $x = (int) round($diff->d / 7, 0);
-        if ($x < 4) {
-            return $x;
+        if ($diff->days < 30) {
+            return (int) floor($diff->days / 7);
         }
         return false;
     }
@@ -186,11 +185,16 @@ class DateTimeAgo
      */
     public function months(DateInterval $diff)
     {
-        $x = (int) round($diff->d / 30, 0);
-        if ($x < 12) {
+        if ($diff->days >= 365) {
+            return FALSE;
+        }
+
+        $x = (int) floor($diff->days / 30.417);
+        if ($x === 0) {
+            return 1;
+        } else {
             return $x;
         }
-        return false;
     }
 
     /**
@@ -200,7 +204,7 @@ class DateTimeAgo
      */
     public function years(DateInterval $diff)
     {
-        return (int) round($diff->d / 365, 0);
+        return (int) floor($diff->days / 365);
     }
     
     /**

--- a/src/Smirik/PHPDateTimeAgo/TextTranslator/EnglishTextTranslator.php
+++ b/src/Smirik/PHPDateTimeAgo/TextTranslator/EnglishTextTranslator.php
@@ -8,7 +8,22 @@ class EnglishTextTranslator extends AbstractTextTranslator
     protected $minute_words = array('minute ago', 'minutes ago');
     protected $hour_words   = array('hour ago', 'hours ago');
     protected $day_words    = array('day ago', 'days ago');
-    
+    protected $week_words   = array('week ago', 'weeks ago');
+    protected $month_words  = array('month ago', 'months ago');
+    protected $year_words   = array('year ago', 'years ago');
+
+    protected $weeks_months_years = FALSE;
+
+    /**
+     * Toggle whether to render weeks/months/years or fall back to date format for longer periods.
+     *
+     * @param bool $enable
+     */
+    public function enableWeeksMonthsYears($enable)
+    {
+        $this->weeks_months_years = $enable;
+    }
+
     /**
      * {@inheritdoc}
      */
@@ -24,5 +39,29 @@ class EnglishTextTranslator extends AbstractTextTranslator
     {
         return ($number == 1) ? 0 : 1;
     }
-    
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsWeeks()
+    {
+        return $this->weeks_months_years;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsMonths()
+    {
+        return $this->weeks_months_years;
+    }
+
+    /**
+     * {@inheritdoc}
+     */
+    public function supportsYears()
+    {
+        return $this->weeks_months_years;
+    }
+
 }


### PR DESCRIPTION
This depends on the fixes in #9 to work properly, but is a separate feature. I have made it backwards compatible for now by adding an extra toggle on the translator - this does feel a bit messy but seemed the best quick way to introduce it without refactoring the existing code.

Obviously the alternative would be to target this for a v2 release and just have it supported by default.