### PR TITLE
Support DateTimeInterface (requires PHP > 5.5)

### DIFF
--- a/.travis.yml
+++ b/.travis.yml
@@ -1,9 +1,10 @@
 language: php
 
 php:
-  - 5.3
-  - 5.4
   - 5.5
+  - 7.0
+  - 7.1
+  - 7.2
 
 before_script:
   - curl -s https://getcomposer.org/installer | php

--- a/composer.json
+++ b/composer.json
@@ -12,7 +12,7 @@
         }
     ],
     "require": {
-        "php": ">=5.3.3"
+        "php": "^5.5|^7.0"
     },
     "autoload": {
         "psr-0": { "Smirik\\PHPDateTimeAgo\\": "src/" }

--- a/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
+++ b/spec/Smirik/PHPDateTimeAgo/DateTimeAgoSpec.php
@@ -71,6 +71,13 @@ class DateTimeAgoSpec extends ObjectBehavior
         $this->get(new \DateTime('-5 days'))->shouldNotBe('5 days ago');
     }
 
+    function it_checks_datetimeimmutable()
+    {
+        $this->get(new \DateTimeImmutable('-5 seconds'))->shouldReturn("now");
+        $this->get(new \DateTimeImmutable('-25 minutes'))->shouldBe('25 minutes ago');
+        $this->get(new \DateTimeImmutable('-119 minutes'))->shouldBe('1 hour ago');
+    }
+
     function it_checks_weeks_in_english_when_enabled()
     {
         $translator = new \Smirik\PHPDateTimeAgo\TextTranslator\EnglishTextTranslator;

--- a/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
+++ b/src/Smirik/PHPDateTimeAgo/DateTimeAgo.php
@@ -4,6 +4,7 @@ namespace Smirik\PHPDateTimeAgo;
 
 use DateInterval;
 use DateTime;
+use DateTimeInterface;
 use Smirik\PHPDateTimeAgo\TextTranslator\EnglishTextTranslator;
 use Smirik\PHPDateTimeAgo\TextTranslator\TextTranslatorInterface;
 
@@ -36,11 +37,11 @@ class DateTimeAgo
     
     /**
      * Get string representation of the date with given translator
-     * @param DateTime $date
-     * @param DateTime|null $reference_date
+     * @param DateTimeInterface $date
+     * @param DateTimeInterface|null $reference_date
      * @return string
      */
-    public function get(DateTime $date, DateTime $reference_date = null )
+    public function get(\DateTimeInterface $date, \DateTimeInterface $reference_date = null )
     {
         if (is_null($reference_date)) {
             $reference_date = new DateTime();
@@ -53,6 +54,7 @@ class DateTimeAgo
     /**
      * Get string related to DateInterval object
      * @param DateInterval $diff
+     * @param DateTimeInterface $date
      * @return string
      */
     public function getText(DateInterval $diff, $date)


### PR DESCRIPTION
Allow passing in either a DateTime or a DateTimeImmutable by
typehinting as the DateTimeInterface added in PHP5.5.

Bumps the bare minimum PHP version to 5.5.x (though all the 5.x
series are no longer supported anyway) and updates composer and
travis to officially test and support on 7.x.

This is backwards compatible for anyone simply using the class,
but is arguably a breaking change if anyone has extended the class
as the method signature of the ->get method has changed and will
produce an incompatible signatures warning...